### PR TITLE
VCTUI can now pass new VM details to plunder

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,28 @@ Pressing `ctrl+p` will open a power management ui (press ctrl+c) to exit this me
                     ╚══════════════════════════════════════╝    
 ```
 
+### Installation / Deployment
+
+This requires a `plunder` server up and running and accessible from where `vctui` is currently running. Navigate to the MAC address of a newly created virtual machine, and press `ctrl+i`. This will present a new menu for configuring the settings of a newly deployed OS through plunder. 
+
+```
+     ╔════════════════════Update deployment═════════════════════╗
+     ║                                                          ║
+     ║ Plunder Address http://localhost                         ║
+     ║                                                          ║
+     ║ MAC Address     00:50:56:9b:2a:b7                        ║
+     ║                                                          ║
+     ║ Hostname        server09                                 ║
+     ║                                                          ║
+     ║ IP Address      192.168.1.3                              ║
+     ║                                                          ║
+     ║ Deployment Type preseed                                  ║
+     ║                                                          ║
+     ║   Save Settings                                          ║
+     ║                                                          ║
+     ╚══════════════════════════════════════════════════════════╝
+```
+
 ### Snapshot
 
 Pressing `ctrl+s` on one of the listed snapshots will revert the virtual machine to that snapshot, and it will be left in the powered off state

--- a/pkg/vctui/builder.go
+++ b/pkg/vctui/builder.go
@@ -89,27 +89,39 @@ func buildTree(v []*object.VirtualMachine) *tview.TreeNode {
 
 func buildDetails(ctx context.Context, vm *object.VirtualMachine, vmo mo.VirtualMachine) *tview.TreeNode {
 
+	// reference is used to label the type of tree Node
+	var r reference
+	r.vm = vm
 	// Add Details subtree information
-	vmDetails := tview.NewTreeNode("Details").SetReference("Details").SetSelectable(true)
+	r.objectType = "Details"
+	vmDetails := tview.NewTreeNode("Details").SetReference(r).SetSelectable(true)
 
-	vmDetail := tview.NewTreeNode(fmt.Sprintf("CPUs: %d", vmo.Summary.Config.NumCpu)).SetReference("Cpu").SetSelectable(true)
+	r.objectType = "CPUs"
+	vmDetail := tview.NewTreeNode(fmt.Sprintf("CPUs: %d", vmo.Summary.Config.NumCpu)).SetReference(r).SetSelectable(true)
 	vmDetails.AddChild(vmDetail)
 
-	vmDetail = tview.NewTreeNode(fmt.Sprintf("Memory: %d", vmo.Summary.Config.MemorySizeMB)).SetReference("memory").SetSelectable(true)
+	r.objectType = "Memory"
+	vmDetail = tview.NewTreeNode(fmt.Sprintf("Memory: %d", vmo.Summary.Config.MemorySizeMB)).SetReference(r).SetSelectable(true)
 	vmDetails.AddChild(vmDetail)
 
-	vmDetail = tview.NewTreeNode(fmt.Sprintf("Type: %s", vmo.Summary.Config.GuestFullName)).SetReference("memory").SetSelectable(true)
+	r.objectType = "VM Type"
+	vmDetail = tview.NewTreeNode(fmt.Sprintf("Type: %s", vmo.Summary.Config.GuestFullName)).SetReference(r).SetSelectable(true)
 	vmDetails.AddChild(vmDetail)
 
-	vmDetail = tview.NewTreeNode(fmt.Sprintf("VMware Tools: %s", vmo.Summary.Guest.ToolsStatus)).SetReference("toolsStatus").SetSelectable(true)
+	r.objectType = "VM Tools"
+	vmDetail = tview.NewTreeNode(fmt.Sprintf("VMware Tools: %s", vmo.Summary.Guest.ToolsStatus)).SetReference(r).SetSelectable(true)
 	vmDetails.AddChild(vmDetail)
 
-	vmDetail = tview.NewTreeNode(fmt.Sprintf("VM IP Address: %s", vmo.Summary.Guest.IpAddress)).SetReference("toolsStatus").SetSelectable(true)
+	r.objectType = "VM Address"
+	vmDetail = tview.NewTreeNode(fmt.Sprintf("VM IP Address: %s", vmo.Summary.Guest.IpAddress)).SetReference(r).SetSelectable(true)
 	vmDetails.AddChild(vmDetail)
 
 	devices, _ := vm.Device(ctx)
 
-	vmDetail = tview.NewTreeNode(fmt.Sprintf("MAC ADDRESS: %s", devices.PrimaryMacAddress())).SetReference("toolsStatus").SetSelectable(true)
+	r.objectType = "MAC"
+	r.objectDetails = devices.PrimaryMacAddress()
+
+	vmDetail = tview.NewTreeNode(fmt.Sprintf("MAC ADDRESS: %s", r.objectDetails)).SetReference(r).SetSelectable(true)
 	vmDetails.AddChild(vmDetail)
 
 	return vmDetails

--- a/pkg/vctui/internals.go
+++ b/pkg/vctui/internals.go
@@ -25,12 +25,6 @@ type vcInternal struct {
 	resourcePool  *object.ResourcePool
 }
 
-var vmTypes = []string{"otherLinux64Guest",
-	"Red Hat Enterprise Linux 6 (64-bit)",
-	"Red Hat Enterprise Linux 6 (32-bit)",
-	"Red Hat Enterprise Linux 7 (64-bit)",
-	"Red Hat Enterprise Linux 7 (32-bit)"}
-
 func (i *vcInternal) parseInternals(c *govmomi.Client) error {
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/vctui/ui.go
+++ b/pkg/vctui/ui.go
@@ -48,7 +48,9 @@ func MainUI(v []*object.VirtualMachine, c *govmomi.Client) error {
 
 	// This section handles all of the input from the end-user
 	//
+	// Ctrl+d = delete function
 	// Ctrl+f = Find function
+	// Ctrl+i = deploy/install function
 	// Ctrl+p = Power function
 	// Ctrl+r = Refresh function
 	// Ctrl+s = Snapshot function
@@ -81,6 +83,23 @@ func MainUI(v []*object.VirtualMachine, c *govmomi.Client) error {
 			}
 			root.ClearChildren()
 			root.SetChildren(newRoot.GetChildren())
+
+		case tcell.KeyCtrlI:
+
+			n := tree.GetCurrentNode()
+			var address, hostname string
+
+			n.Walk(func(node, parent *tview.TreeNode) bool {
+				r := node.GetReference().(reference)
+				if r.objectType == "MAC" {
+					address = r.objectDetails
+					hostname = r.vm.Name()
+					application.Suspend(func() { deployOnVM(address, hostname) })
+					return false
+				}
+				return true
+			})
+			uiBugFix()
 
 		case tcell.KeyCtrlN:
 			// New Virtual Machine functionality

--- a/pkg/vctui/uiDeploy.go
+++ b/pkg/vctui/uiDeploy.go
@@ -1,0 +1,121 @@
+package vctui
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/plunder-app/plunder/pkg/server"
+	"github.com/rivo/tview"
+)
+
+func deployOnVM(address, hostname string) {
+	uiBugFix()
+
+	app := tview.NewApplication()
+
+	form := tview.NewForm()
+	form.AddInputField("Plunder Address", "http://localhost", 40, nil, nil).
+		AddInputField("MAC Address", address, 18, nil, nil).
+		AddInputField("Hostname", hostname, 40, nil, nil).
+		AddInputField("IP Address", "", 18, nil, nil).
+		AddDropDown("Deployment Type", deplopyTypes, 0, nil).
+		AddButton("Save Settings", func() { app.Stop() })
+
+	form.SetBorder(true).
+		SetTitle("Update deployment").
+		SetTitleAlign(tview.AlignCenter).
+		SetRect(5, 1, 60, 23)
+
+	if err := app.SetRoot(form, false).Run(); err != nil {
+		panic(err)
+	}
+	var deployMac, deployHost, deployIP, deployType string
+
+	plunderURL := form.GetFormItemByLabel("Plunder Address").(*tview.InputField).GetText()
+	deployMac = form.GetFormItemByLabel("MAC Address").(*tview.InputField).GetText()
+	deployHost = form.GetFormItemByLabel("Hostname").(*tview.InputField).GetText()
+	deployIP = form.GetFormItemByLabel("IP Address").(*tview.InputField).GetText()
+	_, deployType = form.GetFormItemByLabel("Deployment Type").(*tview.DropDown).GetCurrentOption()
+
+	currentConfig, err := getConfig(plunderURL)
+
+	if err != nil {
+		errorUI(err)
+		return
+	}
+	// Check for existing deployment
+	var updatedExisting bool
+	for i := range currentConfig.Deployments {
+		if currentConfig.Deployments[i].MAC == deployMac {
+			currentConfig.Deployments[i].Deployment = deployType
+			currentConfig.Deployments[i].Config.IPAddress = deployIP
+			currentConfig.Deployments[i].Config.ServerName = deployHost
+			updatedExisting = true
+		}
+	}
+
+	// If we've not updated the existing then it's a new entry
+	if updatedExisting == false {
+		newDeployment := server.DeploymentConfigurations{
+			MAC:        deployMac,
+			Deployment: deployType,
+			Config: server.HostConfig{
+				IPAddress:  deployIP,
+				ServerName: deployHost,
+			},
+		}
+		currentConfig.Deployments = append(currentConfig.Deployments, newDeployment)
+	}
+
+	// Update the deployment server
+	err = postConfig(plunderURL, currentConfig)
+	if err != nil {
+		errorUI(err)
+		return
+	}
+}
+
+func getConfig(plunderURL string) (*server.DeploymentConfigurationFile, error) {
+	u, err := url.Parse(plunderURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/deployment"
+
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	var config server.DeploymentConfigurationFile
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(b, &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func postConfig(plunderURL string, config *server.DeploymentConfigurationFile) error {
+	u, err := url.Parse(plunderURL)
+	if err != nil {
+		return err
+	}
+	u.Path = "/deployment"
+
+	jsonValue, _ := json.Marshal(config)
+
+	_, err = http.Post(u.String(), "application/json", bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/vctui/uiError.go
+++ b/pkg/vctui/uiError.go
@@ -8,7 +8,7 @@ func errorUI(err error) {
 	button := tview.NewButton(err.Error()).SetSelectedFunc(func() {
 		app.Stop()
 	})
-	button.SetBorder(true).SetRect(5, 5, 22, 3)
+	button.SetBorder(true).SetRect(5, 5, 75, 3)
 	if err := app.SetRoot(button, false).Run(); err != nil {
 		panic(err)
 	}

--- a/pkg/vctui/uiTypes.go
+++ b/pkg/vctui/uiTypes.go
@@ -5,6 +5,17 @@ import (
 )
 
 type reference struct {
-	objectType string
-	vm         *object.VirtualMachine
+	objectType    string
+	objectDetails string
+	vm            *object.VirtualMachine
 }
+
+var vmTypes = []string{"otherLinux64Guest",
+	"Red Hat Enterprise Linux 6 (64-bit)",
+	"Red Hat Enterprise Linux 6 (32-bit)",
+	"Red Hat Enterprise Linux 7 (64-bit)",
+	"Red Hat Enterprise Linux 7 (32-bit)"}
+
+var deplopyTypes = []string{"reboot",
+	"preseed",
+	"kickstart"}


### PR DESCRIPTION
This PR adds a `ctrl+i` option (when selecting a VMs MAC address) allowing the passing of installation instructions to `plunder`.