### PR TITLE
Should fix an issue where a reference is accessed as a struct when it…

### DIFF
--- a/cmd/vctui.go
+++ b/cmd/vctui.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/thebsdbox/vctui/pkg/vctui"
 	"github.com/vmware/govmomi"
 

--- a/pkg/vctui/builder.go
+++ b/pkg/vctui/builder.go
@@ -129,10 +129,11 @@ func buildDetails(ctx context.Context, vm *object.VirtualMachine, vmo mo.Virtual
 
 func buildSnapshots(ctx context.Context, vm *object.VirtualMachine, vmo mo.VirtualMachine) *tview.TreeNode {
 	// Add Snapshots subtree information
-	vmSnapshots := tview.NewTreeNode("snapshots").SetReference("snapshots").SetSelectable(true)
 	var r reference
-	r.objectType = "snapshot"
+	r.objectType = "snapshots"
 	r.vm = vm
+	vmSnapshots := tview.NewTreeNode("snapshots").SetReference(r).SetSelectable(true)
+	r.objectType = "snapshot"
 	if vmo.Snapshot != nil {
 		if len(vmo.Snapshot.RootSnapshotList) != 0 {
 			for i := range vmo.Snapshot.RootSnapshotList {

--- a/pkg/vctui/ui.go
+++ b/pkg/vctui/ui.go
@@ -90,6 +90,10 @@ func MainUI(v []*object.VirtualMachine, c *govmomi.Client) error {
 			var address, hostname string
 
 			n.Walk(func(node, parent *tview.TreeNode) bool {
+				// Ensure we don't parse an object with no reference
+				if node.GetReference() == nil {
+					return false
+				}
 				r := node.GetReference().(reference)
 				if r.objectType == "MAC" {
 					address = r.objectDetails


### PR DESCRIPTION
…'s a string

This fixes an interface{} being a string not a struct, also fixes an incorrect import